### PR TITLE
🔧 fix: Escape special characters in commit messages for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,14 +110,16 @@ jobs:
             COMMITS=$(git log ${LATEST_TAG}..HEAD --oneline --pretty=format:"%s")
           fi
           
-          # 將 commits 格式化為列表
+          # 將 commits 格式化為列表，並處理特殊字符
           COMMIT_LIST=""
           while IFS= read -r line; do
             if [ -n "$line" ]; then
+              # 清理可能導致問題的特殊字符
+              clean_line=$(echo "$line" | sed 's/["`$\\]/\\&/g')
               if [ -n "$COMMIT_LIST" ]; then
-                COMMIT_LIST="${COMMIT_LIST}\n- ${line}"
+                COMMIT_LIST="${COMMIT_LIST}\n- ${clean_line}"
               else
-                COMMIT_LIST="- ${line}"
+                COMMIT_LIST="- ${clean_line}"
               fi
             fi
           done <<< "$COMMITS"
@@ -147,7 +149,7 @@ jobs:
           echo "## ${VERSION_TYPE}" > release_notes.md
           echo "" >> release_notes.md
           echo "## Changes" >> release_notes.md
-          echo "${COMMIT_LIST}" >> release_notes.md
+          echo -e "${COMMIT_LIST}" >> release_notes.md
           echo "" >> release_notes.md
           echo "---" >> release_notes.md
           echo "🚀 **Deployed to**: https://${{ github.repository_owner }}.github.io/cword" >> release_notes.md


### PR DESCRIPTION
## 修復內容

### 問題
Release workflow 在處理 commit 訊息時遇到特殊字符導致 shell 解析錯誤：
- 錯誤: `Code: command not found`
- 原因: commit 訊息中的特殊字符（如引號、反引號等）未正確轉義

### 修復方案
1. **字符轉義**: 使用 `sed` 對可能導致問題的特殊字符進行轉義
2. **安全處理**: 清理 `"`$\` 等特殊字符
3. **改進輸出**: 使用 `echo -e` 正確處理換行符

### 測試
- [x] YAML 語法驗證通過
- [x] 特殊字符處理邏輯確認正確

這個修復應該能解決 release workflow 中的字符解析問題。