### PR TITLE
🔧 fix: Fix TypeScript compilation error for gtag declarations

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -10,3 +10,5 @@ declare global {
     ) => void;
   }
 }
+
+export {};


### PR DESCRIPTION
## 🔧 修復 TypeScript 編譯錯誤

### 🐛 問題
GitHub Actions workflow 失敗，出現 TypeScript 編譯錯誤：
```
error TS2339: Property 'gtag' does not exist on type 'Window & typeof globalThis'.
```

### 🛠️ 解決方案
在 `src/vite-env.d.ts` 中添加 `export {}` 語句，使其成為正確的模組文件。

### 📋 修復內容
- **添加 export 語句**: 讓 TypeScript 正確識別全域類型聲明
- **修復 gtag 類型**: 確保 `window.gtag` 類型聲明生效
- **解決編譯錯誤**: 讓 GitHub Actions workflow 能夠成功建置

### ✅ 測試結果
- TypeScript 編譯通過
- Google Analytics 追蹤功能正常
- 所有路由功能保持正常

這個修復確保了：
- 🔧 TypeScript 編譯不再出錯
- 📊 Google Analytics 類型安全
- 🚀 GitHub Actions 部署成功