### PR TITLE
🔧 refactor: Move logout to bottom and switch to localStorage for API keys

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -13,14 +13,12 @@ interface PageHeaderProps {
   title: string;
   icon: string;
   userProfile: IUserProfile | null;
-  onLogout: () => void;
 }
 
 export const PageHeader: React.FC<PageHeaderProps> = ({
   title,
   icon,
-  userProfile,
-  onLogout
+  userProfile
 }) => {
   const getAvatarSrc = (avatarId: string): string => {
     const avatarMap: Record<string, string> = {
@@ -99,13 +97,6 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
             >
               <i className="ri-github-fill text-white text-lg"></i>
             </a>
-            <button
-              onClick={onLogout}
-              className="w-10 h-10 bg-red-600 hover:bg-red-700 rounded-lg flex items-center justify-center border-2 border-red-700 transition-colors"
-              title="登出"
-            >
-              <i className="ri-logout-box-line text-white text-lg"></i>
-            </button>
           </div>
         </div>
       </div>
@@ -142,13 +133,6 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
           >
             <i className="ri-github-fill text-white text-xl"></i>
           </a>
-          <button
-            onClick={onLogout}
-            className="w-12 h-12 bg-red-600 hover:bg-red-700 rounded-lg flex items-center justify-center border-2 border-red-700 transition-colors"
-            title="登出"
-          >
-            <i className="ri-logout-box-line text-white text-xl"></i>
-          </button>
         </div>
       </div>
     </header>

--- a/src/pages/AdventurerCabin.tsx
+++ b/src/pages/AdventurerCabin.tsx
@@ -175,13 +175,13 @@ const AdventurerCabin: React.FC = () => {
   };
 
   const handleLogout = async () => {
-    if (confirm('確定要登出嗎？這將會清除所有學習紀錄和設定。')) {
+    if (confirm('確定要刪除帳號嗎？這將會清除所有的學習紀錄和設定，而且無法還原。')) {
       try {
         await DatabaseService.clearAllData();
         window.location.href = '/';
       } catch (err) {
         console.error('Logout failed:', err);
-        alert('登出失敗，請重試');
+        alert('刪除帳號失敗，請重試');
       }
     }
   };
@@ -360,7 +360,6 @@ const AdventurerCabin: React.FC = () => {
           title="冒險者小屋"
           icon="🏠"
           userProfile={userProfile}
-          onLogout={handleLogout}
         />
 
         <div className="px-6 pb-6">
@@ -705,6 +704,16 @@ const AdventurerCabin: React.FC = () => {
           icon="ri-building-line"
           label="冒險者公會"
         />
+        
+        {/* Delete Account Link at bottom */}
+        <div className="text-center pb-8">
+          <button
+            onClick={handleLogout}
+            className="text-red-400 hover:text-gray-500 text-sm underline transition-colors hover:cursor-pointer"
+          >
+            刪除帳號
+          </button>
+        </div>
       </div>
     </>
   );

--- a/src/pages/AdventurerCabin.tsx
+++ b/src/pages/AdventurerCabin.tsx
@@ -186,6 +186,25 @@ const AdventurerCabin: React.FC = () => {
     }
   };
 
+  const handleDeleteApiKey = () => {
+    if (confirm('確定要刪除 API Key 嗎？刪除後需要重新設定才能繼續使用 AI 助手。')) {
+      try {
+        // 清除所有可能的 API Key 儲存
+        localStorage.removeItem('ai_api_key');
+        localStorage.removeItem('ai_model');
+        localStorage.removeItem('openai_api_key');
+        localStorage.removeItem('claude_api_key');
+        localStorage.removeItem('gemini_api_key');
+        alert('API Key 已刪除，請重新設定後繼續使用');
+        // 可以選擇重新載入頁面或導向設定頁面
+        window.location.reload();
+      } catch (err) {
+        console.error('Delete API Key failed:', err);
+        alert('刪除 API Key 失敗，請重試');
+      }
+    }
+  };
+
   const getAvailableCoinsForExchange = () => {
     const paidOutWeeks = weeklyHistory.filter(w => w.status === 'paid_out');
     if (paidOutWeeks.length === 0) return 0;
@@ -377,6 +396,15 @@ const AdventurerCabin: React.FC = () => {
                   <p><span className="font-semibold">年級：</span>國小 {UserProfileService.getDisplayGrade(userProfile?.age || 8)} 年級</p>
                   <p><span className="font-semibold">AI 助手：</span>{userProfile?.aiModel?.toUpperCase()}</p>
                   <p><span className="font-semibold">加入時間：</span>{formatDate(userProfile?.createdAt || new Date())}</p>
+                </div>
+                <div className="mt-4">
+                  <button
+                    onClick={handleDeleteApiKey}
+                    className="bg-red-500 hover:bg-red-600 text-white px-2 py-1 rounded-lg text-sm transition-colors hover:cursor-pointer"
+                    title="刪除 API Key"
+                  >
+                    刪除 API Key
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/pages/AdventurerGuild.tsx
+++ b/src/pages/AdventurerGuild.tsx
@@ -122,9 +122,9 @@ const AdventurerGuild: React.FC = () => {
       const profile = await UserProfileService.getUserProfile();
       setUserProfile(profile || null);
 
-      // Get API configuration from session storage
-      const apiKey = sessionStorage.getItem('ai_api_key');
-      const aiModel = sessionStorage.getItem('ai_model') as 'gemini' | 'openai' | 'claude';
+      // Get API configuration from local storage
+      const apiKey = localStorage.getItem('ai_api_key');
+      const aiModel = localStorage.getItem('ai_model') as 'gemini' | 'openai' | 'claude';
 
       if (!apiKey || !aiModel) {
         const configError = new AIServiceError('API 設定遺失，請重新設定', 'AUTH_ERROR');
@@ -256,9 +256,9 @@ const AdventurerGuild: React.FC = () => {
 
   const handleApiConfigSave = async (apiKey: string, model: AIModel) => {
     try {
-      // Update session storage
-      sessionStorage.setItem('ai_api_key', apiKey);
-      sessionStorage.setItem('ai_model', model);
+      // Update local storage
+      localStorage.setItem('ai_api_key', apiKey);
+      localStorage.setItem('ai_model', model);
 
       // Update user profile
       if (userProfile && userProfile.id) {

--- a/src/pages/ProfileSetup.tsx
+++ b/src/pages/ProfileSetup.tsx
@@ -211,9 +211,9 @@ const ProfileSetup: React.FC = () => {
     setError('');
 
     try {
-      // Store API key in session storage
-      sessionStorage.setItem('ai_api_key', formData.apiKey);
-      sessionStorage.setItem('ai_model', formData.aiModel);
+      // Store API key in local storage
+      localStorage.setItem('ai_api_key', formData.apiKey);
+      localStorage.setItem('ai_model', formData.aiModel);
 
       // Create user profile (without API key)
       await UserProfileService.createUser({

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -85,9 +85,12 @@ export class DatabaseService {
       await db.dailyTasks.clear();
       await db.weeklyLedger.clear();
       
-      // Clear session storage for API keys
-      sessionStorage.removeItem('ai_api_key');
-      sessionStorage.removeItem('ai_model');
+      // Clear local storage for API keys
+      localStorage.removeItem('ai_api_key');
+      localStorage.removeItem('ai_model');
+      localStorage.removeItem('openai_api_key');
+      localStorage.removeItem('claude_api_key');
+      localStorage.removeItem('gemini_api_key');
       
       console.log('All data cleared successfully');
     } catch (error) {


### PR DESCRIPTION
## Summary
• Moved dangerous logout functionality from prominent header position to inconspicuous bottom location
• Changed all storage from sessionStorage to localStorage for persistent API key storage
• Added dedicated API Key deletion functionality for user convenience

## Changes Made
• **PageHeader.tsx**: Removed logout button from header to prevent accidental account deletion
• **AdventurerCabin.tsx**: 
  - Added subtle "Delete Account" text link at page bottom
  - Added separate "Delete API Key" button for clearing API credentials
  - Updated handleDeleteApiKey to clear all localStorage API keys
• **Database.ts**: Updated clearAllData to use localStorage instead of sessionStorage
• **ProfileSetup.tsx**: Changed to store API keys in localStorage for persistence
• **AdventurerGuild.tsx**: Updated to read API configuration from localStorage

## Test plan
- [x] Test API key persistence across browser sessions
- [x] Verify API key deletion functionality works correctly
- [x] Confirm account deletion is now safely tucked away at bottom
- [x] Ensure all existing functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)