### PR TITLE
🔧 fix: Remove unused onLogout prop from PageHeader

### DIFF
--- a/src/pages/AdventurerGuild.tsx
+++ b/src/pages/AdventurerGuild.tsx
@@ -284,17 +284,6 @@ const AdventurerGuild: React.FC = () => {
     await loadData();
   };
 
-  const handleLogout = async () => {
-    if (confirm('確定要登出嗎？這將會清除所有學習紀錄和設定。')) {
-      try {
-        await DatabaseService.clearAllData();
-        window.location.href = '/';
-      } catch (err) {
-        console.error('Logout failed:', err);
-        setError('登出失敗，請重試');
-      }
-    }
-  };
 
   const getTaskIcon = (type: IDailyTask['type']) => {
     switch (type) {
@@ -377,7 +366,6 @@ const AdventurerGuild: React.FC = () => {
           title="冒險者公會"
           icon="🏛️"
           userProfile={userProfile}
-          onLogout={handleLogout}
         />
 
         <div className="px-6 pb-6">


### PR DESCRIPTION
## Summary
Fixed TypeScript compilation error caused by passing removed onLogout prop to PageHeader component in AdventurerGuild.tsx

## Changes
• Removed unused onLogout prop from PageHeader usage in AdventurerGuild.tsx
• Removed unused handleLogout function from AdventurerGuild.tsx

## Fixes
• Resolves TypeScript error: Property 'onLogout' does not exist on type 'PageHeaderProps'
• Allows successful build and deployment

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>