### PR TITLE
🔧 fix: Remove unused DatabaseService import causing build failure

### DIFF
--- a/src/pages/AdventurerGuild.tsx
+++ b/src/pages/AdventurerGuild.tsx
@@ -4,7 +4,6 @@ import { AIServiceError } from '../types';
 import { TaskGenerationService } from '../services/taskGeneration.service';
 import { UserProfileService } from '../services/userProfile.service';
 import { WeeklyLedgerService } from '../services/weeklyLedger.service';
-import { DatabaseService } from '../services/database';
 import ApiConfigModal from '../components/ApiConfigModal';
 import TaskExecutionModal from '../components/TaskExecutionModal';
 import { PageHeader } from '../components/PageHeader';


### PR DESCRIPTION
## Summary
Fixed TypeScript compilation error by removing unused DatabaseService import from AdventurerGuild.tsx

## Changes
• Removed unused  import from AdventurerGuild.tsx that was causing  error

## Fixes
• Resolves TypeScript error: 
• Allows successful build and deployment

## Test Results
✅ Local build passes successfully with 
> word-adventure-island@1.0.0 build
> tsc -b && vite build

vite v7.1.3 building for production...
transforming...
✓ 1798 modules transformed.
rendering chunks...
computing gzip size...
dist/assets/warrior-DUFgvF7e.svg     1.14 kB │ gzip:   0.42 kB
dist/assets/mage-MJB5PuvJ.svg        1.26 kB │ gzip:   0.45 kB
dist/assets/healer-204wvNJS.svg      1.37 kB │ gzip:   0.49 kB
dist/assets/archer-DtSx5Tm7.svg      1.41 kB │ gzip:   0.46 kB
dist/assets/explorer-DIGZH3Tc.svg    1.53 kB │ gzip:   0.48 kB
dist/index.html                      1.56 kB │ gzip:   0.85 kB
dist/assets/scholar-PAukrYHw.svg     1.77 kB │ gzip:   0.50 kB
dist/assets/index-BNnSt0TA.css      49.13 kB │ gzip:   9.09 kB
dist/assets/index-Bj0k4aQU.js      546.37 kB │ gzip: 174.05 kB
✓ built in 1.22s
✅ TypeScript compilation with  passes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>