### PR TITLE
✨ feat: Add unique page titles for better GA tracking

### DIFF
--- a/src/pages/AdventurerCabin.tsx
+++ b/src/pages/AdventurerCabin.tsx
@@ -81,6 +81,7 @@ const AdventurerCabin: React.FC = () => {
   const [exchangeResult, setExchangeResult] = useState<any>(null);
 
   useEffect(() => {
+    document.title = '冒險者小屋 | 生字冒險島';
     loadData();
   }, []);
 

--- a/src/pages/AdventurerGuild.tsx
+++ b/src/pages/AdventurerGuild.tsx
@@ -110,6 +110,7 @@ const AdventurerGuild: React.FC = () => {
   const [selectedTask, setSelectedTask] = useState<IDailyTask | null>(null);
 
   useEffect(() => {
+    document.title = '冒險者公會 | 生字冒險島';
     loadData();
   }, []);
 

--- a/src/pages/ProfileSetup.tsx
+++ b/src/pages/ProfileSetup.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { UserProfileService } from '../services/userProfile.service';
 import type { AIModel } from '../types';
@@ -160,6 +160,10 @@ const ProfileSetup: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
   const navigate = useNavigate();
+
+  useEffect(() => {
+    document.title = '開始冒險 | 生字冒險島';
+  }, []);
 
   // 頭像選項定義 - 像素風格職業頭像
   const avatars = [


### PR DESCRIPTION
## Summary
Added unique page titles for better Google Analytics tracking and user identification

## Changes Made
• **ProfileSetup.tsx**: Set page title to '開始冒險 | 生字冒險島'
• **AdventurerGuild.tsx**: Set page title to '冒險者公會 | 生字冒險島'  
• **AdventurerCabin.tsx**: Set page title to '冒險者小屋 | 生字冒險島'

## Benefits
• Improved GA reporting with clear page identification
• Better browser tab management for users
• Enhanced SEO with descriptive page titles

## Technical Details
• Used useEffect to set document.title on component mount
• Maintains consistent format: '[Page Name] | 生字冒險島'
• No breaking changes to existing functionality

## Test Plan
- [x] Local build passes successfully
- [x] All pages display correct titles
- [x] No TypeScript errors
- [x] No runtime errors

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>