### PR TITLE
🐛 fix: GitHub Pages routing for logout functionality

### DIFF
--- a/src/pages/AdventurerCabin.tsx
+++ b/src/pages/AdventurerCabin.tsx
@@ -185,7 +185,7 @@ const AdventurerCabin: React.FC = () => {
     if (confirm('確定要刪除帳號嗎？這將會清除所有的學習紀錄和設定，而且無法還原。')) {
       try {
         await DatabaseService.clearAllData();
-        window.location.href = '/';
+        window.location.href = import.meta.env.BASE_URL;
       } catch (err) {
         console.error('Logout failed:', err);
         alert('刪除帳號失敗，請重試');
@@ -250,7 +250,7 @@ const AdventurerCabin: React.FC = () => {
         localStorage.removeItem('ai_model');
         alert('試用模式已結束！請重新進入設定頁面配置你的 API Key。');
         // 導向首頁重新設定
-        window.location.href = '/';
+        window.location.href = import.meta.env.BASE_URL;
       } catch (err) {
         console.error('End trial failed:', err);
         alert('結束試用失敗，請重試');


### PR DESCRIPTION
## 🐛 Bug Fix Summary

This PR fixes a critical routing issue that caused 404 errors when users logout on the GitHub Pages deployment.

## 🔍 Problem Description

- **Issue**: When users clicked "Delete Account" on GitHub Pages, they were redirected to  instead of 
- **Root Cause**: Hardcoded  in 
- **Impact**: Users encountered 404 errors after logout on production deployment

## ✅ Solution

### Technical Changes
- Replace hardcoded  paths with 
- Leverages Vite's base URL configuration that automatically handles different environments

### Code Changes
```javascript
// Before (causing 404 on GitHub Pages)
window.location.href = '/';

// After (works correctly in all environments)
window.location.href = import.meta.env.BASE_URL;
```

### Environment Behavior
- **Local Development**:  → redirects to 
- **GitHub Pages**:  → redirects to 

## 📝 Files Modified

- 
  - Fixed  function
  - Fixed  function

## 🧪 Testing

- [x] Local development - logout redirects correctly
- [x] Build process completes successfully
- [x] Base URL configuration verified in 

## 📋 Impact

- **Users**: No more 404 errors when logging out on GitHub Pages
- **Development**: No changes to local development experience
- **Deployment**: Seamless routing across all environments

## 🚀 Deployment Notes

- No additional configuration required
- Vite automatically handles base URL injection during build
- Changes are backwards compatible

---

**Related**: This fix ensures the logout functionality works consistently across all deployment environments.